### PR TITLE
Implement caching for UTI and DateFormatters

### DIFF
--- a/NextcloudKit/NKModel.swift
+++ b/NextcloudKit/NKModel.swift
@@ -336,7 +336,6 @@ import SwiftyJSON
     @objc public var checksums = ""
     @objc public var creationDate: NSDate?
     @objc public var dataFingerprint = ""
-    @objc public var date = NSDate()
     @objc public var directory: Bool = false
     @objc public var downloadURL = ""
     @objc public var e2eEncrypted: Bool = false
@@ -380,6 +379,15 @@ import SwiftyJSON
     @objc public var urlBase = ""
     @objc public var user = ""
     @objc public var userId = ""
+
+    @objc public var dateString = ""
+    @objc public lazy var date: NSDate = {
+        if let date = NKCommon.shared.convertDate(dateString, format: "EEE, dd MMM y HH:mm:ss zzz") {
+            return date
+        } else {
+            return NSDate()
+        }
+    }()
 }
 
 @objc public class NKNotifications: NSObject {
@@ -1122,9 +1130,7 @@ class NKDataFileXML: NSObject {
             let propstat = element["d:propstat"][0]
                         
             if let getlastmodified = propstat["d:prop", "d:getlastmodified"].text {
-                if let date = NKCommon.shared.convertDate(getlastmodified, format: "EEE, dd MMM y HH:mm:ss zzz") {
-                    file.date = date
-                }
+                file.dateString = getlastmodified
             }
             
             if let creationtime = propstat["d:prop", "nc:creation_time"].double {


### PR DESCRIPTION
While looking into https://github.com/nextcloud/talk-ios/issues/946 I noticed 2 areas where performance can be improved:
<img width="1101" alt="image" src="https://user-images.githubusercontent.com/1580193/200874394-11bfd6cf-8841-4e45-bedd-0a7b43d0092f.png">
One is date handling and one is UTI handling. 

This PR adds caching in places where it made sense, after the PR the profiling looks like this:
![image](https://user-images.githubusercontent.com/1580193/200874842-38aafce0-e5bb-43dd-9f4e-a84f1391bc36.png)

I did run several tests to determine what makes sense. My test folder consists of 1021 files, 2 folders and around 1,4 GB of files ("/Talk"). Tests were done like this (so just the converting, no network activity):

```diff
diff --git a/NextcloudKit/WebDAV/NextcloudKit+WebDAV.swift b/NextcloudKit/WebDAV/NextcloudKit+WebDAV.swift
index ce5e65c..53b6588 100644
--- a/NextcloudKit/WebDAV/NextcloudKit+WebDAV.swift
+++ b/NextcloudKit/WebDAV/NextcloudKit+WebDAV.swift
@@ -239,8 +239,11 @@ extension NextcloudKit {
                 options.queue.async { completion(account, files, nil, error) }
             case .success( _):
                 if let xmlData = response.data {
+                    let startTime = CFAbsoluteTimeGetCurrent()
                     files = NKDataFileXML().convertDataFile(xmlData: xmlData, dav: dav, urlBase: urlBase, user: user, userId: userId, showHiddenFiles: showHiddenFiles)
                     options.queue.async { completion(account, files, xmlData, .success) }
+                    let timeElapsed = CFAbsoluteTimeGetCurrent() - startTime
+                    print("Elapsed: \(timeElapsed) s")
                 } else {
                     options.queue.async { completion(account, files, nil, .xmlError) }
                 }
```

Results:
```
Original
Elapsed: 20.474599957466125 s
Elapsed: 21.04942297935486 s
Elapsed: 21.118688941001892 s

Cached DateFormatter:
Elapsed: 19.68568205833435 s
Elapsed: 20.38596498966217 s
Elapsed: 20.67156493663788 s

Lazy Date:
Elapsed: 18.591894030570984 s
Elapsed: 18.96753704547882 s
Elapsed: 18.888224005699158 s

Cached UTI
Elapsed: 13.251657962799072 s
Elapsed: 13.313650012016296 s
Elapsed: 13.511384010314941 s

Cached MimeType
Elapsed: 13.352138042449951 s
Elapsed: 12.624964952468872 s
Elapsed: 12.715412020683289 s

Cached FileProperties
Elapsed: 5.698162078857422 s
Elapsed: 5.549528002738953 s
Elapsed: 5.532379984855652 s
```

If I also add the changes in https://github.com/nextcloud/talk-ios/issues/946 (because we don't need most of the properties) I'm now down to:
```
With talk changes
Elapsed: 2.637057065963745 s
Elapsed: 2.553444027900696 s
Elapsed: 2.5751129388809204 s
```
