### PR TITLE
Use NSCache to fix concurrency issue

### DIFF
--- a/NextcloudKit/NKModel.swift
+++ b/NextcloudKit/NKModel.swift
@@ -390,6 +390,15 @@ import SwiftyJSON
     }()
 }
 
+@objcMembers public class NKFileProperty: NSObject {
+
+    public var classFile: String = ""
+    public var iconName: String = ""
+    public var name: String = ""
+    public var ext: String = ""
+
+}
+
 @objc public class NKNotifications: NSObject {
     
     @objc public var actions: Data?


### PR DESCRIPTION
Fix the concurrency issue introduced in #7 (as swift dictionaries are not thread safe...). This one uses `NSCache` now, according to the docs:

> You can add, remove, and query items in the cache from different threads without having to lock the cache yourself.

This one also adds `NKFileProperty`, because we need a class to store in NSCache. 
As swifts `String` is not supported by `NSCache`, we now bridge to `NSString` where needed.