### PR TITLE
Mocker dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,15 +26,15 @@ let package = Package(
     targets: [
         .target(
             name: "NextcloudKit",
-            dependencies: ["Alamofire","SwiftyJSON","SwiftyXMLParser","Mocker"]),
+            dependencies: ["Alamofire", "SwiftyJSON", "SwiftyXMLParser"]),
         .testTarget(
             name: "NextcloudKitUnitTests",
-            dependencies: ["NextcloudKit"],
+            dependencies: ["NextcloudKit", "Mocker"],
             resources: [
                 .process("Resources")
             ]),
         .testTarget(
             name: "NextcloudKitIntegrationTests",
-            dependencies: ["NextcloudKit"])
+            dependencies: ["NextcloudKit", "Mocker"])
     ]
 )


### PR DESCRIPTION
`Mocker` is only needed in the test targets, not in `NextcloudKit` itself. Having it as a dependency in `NextcloudKit` leads to issues when not also linking to other test libraries, e.g. `XCTest`:

<img width="789" alt="image" src="https://github.com/nextcloud/NextcloudKit/assets/1580193/3225eae5-567d-4ae7-b608-75a3f138c0a1">
