### PR TITLE
Track ocId in NKTrash items

### DIFF
--- a/Sources/NextcloudKit/Models/NKTrash.swift
+++ b/Sources/NextcloudKit/Models/NKTrash.swift
@@ -6,6 +6,7 @@
 import Foundation
 
 public class NKTrash: NSObject {
+    public var ocId = ""
     public var contentType = ""
     public var date = Date()
     public var directory: Bool = false

--- a/Sources/NextcloudKit/NKDataFileXML.swift
+++ b/Sources/NextcloudKit/NKDataFileXML.swift
@@ -642,6 +642,10 @@ class NKDataFileXML: NSObject {
                 file.contentType = "httpd/unix-directory"
             }
 
+            if let ocId = propstat["d:prop", "oc:id"].text {
+                file.ocId = ocId
+            }
+
             if let fileId = propstat["d:prop", "oc:fileid"].text {
                 file.fileId = fileId
             }


### PR DESCRIPTION
We are implementing trash container enumeration support in the VFS desktop client and this would make our lives a lot easier :)

The ocId is already requested in the properties when listing trash items so we just need to include this in the class properties