### PR TITLE
Allow setting a different destination file name from local file name in chunked upload

### DIFF
--- a/Sources/NextcloudKit/NextcloudKit+Upload.swift
+++ b/Sources/NextcloudKit/NextcloudKit+Upload.swift
@@ -97,6 +97,7 @@ public extension NextcloudKit {
 
     func uploadChunk(directory: String,
                      fileName: String,
+                     destinationFileName: String? = nil,
                      date: Date?,
                      creationDate: Date?,
                      serverUrl: String,
@@ -119,7 +120,7 @@ public extension NextcloudKit {
         }
         let fileNameLocalSize = self.nkCommonInstance.getFileSize(filePath: directory + "/" + fileName)
         let serverUrlChunkFolder = nkSession.urlBase + "/" + nkSession.dav + "/uploads/" + nkSession.userId + "/" + chunkFolder
-        let serverUrlFileName = nkSession.urlBase + "/" + nkSession.dav + "/files/" + nkSession.userId + self.nkCommonInstance.returnPathfromServerUrl(serverUrl, urlBase: nkSession.urlBase, userId: nkSession.userId) + "/" + fileName
+        let serverUrlFileName = nkSession.urlBase + "/" + nkSession.dav + "/files/" + nkSession.userId + self.nkCommonInstance.returnPathfromServerUrl(serverUrl, urlBase: nkSession.urlBase, userId: nkSession.userId) + "/" + (destinationFileName ?? fileName)
         if options.customHeader == nil {
             options.customHeader = [:]
         }


### PR DESCRIPTION
Using macOS File Provider APIs we rely on the system to provide us with a URL pointing to an item's local modified contents. This URL's last path component is a UUID and does not represent the expected file name of the item.

The current API of uploadChunk presents a problem because it assumes the local content file's filename is the same as what will eventually be uploaded to the server. This PR addresses the issue by allowing users of this function to provide a destination file name which will replace the provided local filename, if used.