### PR TITLE
Get Download Limit

### DIFF
--- a/Sources/NextcloudKit/Models/NKFile.swift
+++ b/Sources/NextcloudKit/Models/NKFile.swift
@@ -21,7 +21,7 @@ public class NKFile: NSObject {
     /// Download limits for shares of this file.
     ///
     public var downloadLimits = [NKDownloadLimit]()
-    
+
     public var e2eEncrypted: Bool = false
     public var etag = ""
     public var favorite: Bool = false

--- a/Sources/NextcloudKit/NKSession.swift
+++ b/Sources/NextcloudKit/NKSession.swift
@@ -140,7 +140,7 @@ public class NKSession {
         #if os(iOS) || targetEnvironment(macCatalyst)
             configurationUploadBackgroundExt.multipathServiceType = .handover
         #endif
-        
+
         configurationUploadBackgroundExt.httpCookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: sharedCookieStorage)
         sessionUploadBackgroundExt = URLSession(configuration: configurationUploadBackgroundExt, delegate: backgroundSessionDelegate, delegateQueue: OperationQueue.main)
     }

--- a/Sources/NextcloudKit/NextcloudKit+ShareDownloadLimit.swift
+++ b/Sources/NextcloudKit/NextcloudKit+ShareDownloadLimit.swift
@@ -4,10 +4,80 @@
 
 import Alamofire
 import Foundation
+import SwiftyJSON
 
 public extension NextcloudKit {
     private func makeEndpoint(with token: String) -> String {
         "ocs/v2.php/apps/files_downloadlimit/api/v1/\(token)/limit"
+    }
+
+    func getDownloadLimit(account: String, token: String, completion: @escaping (NKDownloadLimit?, NKError) -> Void) {
+        let endpoint = makeEndpoint(with: token)
+        let options = NKRequestOptions()
+
+        guard let nkSession = nkCommonInstance.getSession(account: account),
+              let url = nkCommonInstance.createStandardUrl(serverUrl: nkSession.urlBase, endpoint: endpoint, options: options),
+              let headers = nkCommonInstance.getStandardHeaders(account: account, options: options) else {
+            return options.queue.async {
+                completion(nil, .urlError)
+            }
+        }
+
+        nkSession
+            .sessionData
+            .request(url, method: .get, parameters: nil, encoding: URLEncoding.default, headers: headers, interceptor: nil)
+            .validate(statusCode: 200..<300)
+            .responseData(queue: self.nkCommonInstance.backgroundQueue) { response in
+                if self.nkCommonInstance.levelLog > 0 {
+                    debugPrint(response)
+                }
+
+                switch response.result {
+                case .failure(let error):
+                    let error = NKError(error: error, afResponse: response, responseData: response.data)
+
+                    options.queue.async {
+                        completion(nil, error)
+                    }
+                case .success(let jsonData):
+                    let json = JSON(jsonData)
+
+                    guard json["ocs"]["meta"]["statuscode"].int == 200 else {
+                        let error = NKError(rootJson: json, fallbackStatusCode: response.response?.statusCode)
+
+                        options.queue.async {
+                            completion(nil, error)
+                        }
+
+                        return
+                    }
+
+                    let count = json["ocs"]["data"]["count"]
+                    let limit = json["ocs"]["data"]["limit"]
+
+                    guard count.type != .null else {
+                        options.queue.async {
+                            completion(nil, .success)
+                        }
+
+                        return
+                    }
+
+                    guard limit.type != .null else {
+                        options.queue.async {
+                            completion(nil, .success)
+                        }
+
+                        return
+                    }
+
+                    let downloadLimit = NKDownloadLimit(count: count.intValue, limit: limit.intValue, token: token)
+
+                    options.queue.async {
+                        completion(downloadLimit, .success)
+                    }
+                }
+            }
     }
 
     func removeShareDownloadLimit(account: String, token: String, completion: @escaping (_ error: NKError) -> Void) {

--- a/Sources/NextcloudKit/NextcloudKit.swift
+++ b/Sources/NextcloudKit/NextcloudKit.swift
@@ -68,7 +68,20 @@ open class NextcloudKit {
         if nkCommonInstance.nksessions.filter({ $0.account == account }).first != nil {
             return updateSession(account: account, urlBase: urlBase, userId: userId, password: password, userAgent: userAgent, nextcloudVersion: nextcloudVersion)
         }
-        let nkSession = NKSession(urlBase: urlBase, user: user, userId: userId, password: password, account: account, userAgent: userAgent, nextcloudVersion: nextcloudVersion, groupIdentifier: groupIdentifier, httpMaximumConnectionsPerHost: httpMaximumConnectionsPerHost, httpMaximumConnectionsPerHostInDownload: httpMaximumConnectionsPerHostInDownload, httpMaximumConnectionsPerHostInUpload: httpMaximumConnectionsPerHostInUpload)
+        
+        let nkSession = NKSession(
+            urlBase: urlBase,
+            user: user,
+            userId: userId,
+            password: password,
+            account: account,
+            userAgent: userAgent,
+            nextcloudVersion: nextcloudVersion,
+            groupIdentifier: groupIdentifier,
+            httpMaximumConnectionsPerHost: httpMaximumConnectionsPerHost,
+            httpMaximumConnectionsPerHostInDownload: httpMaximumConnectionsPerHostInDownload,
+            httpMaximumConnectionsPerHostInUpload: httpMaximumConnectionsPerHostInUpload
+        )
 
         nkCommonInstance.nksessions.append(nkSession)
     }


### PR DESCRIPTION
A simple extension to get a download limit by share token explicitly and independent from the file's properties as before.

Part of https://github.com/nextcloud/ios/issues/3184