### PR TITLE
Fix: Login Polling Without Cached Responses

### DIFF
--- a/Sources/NextcloudKit/NextcloudKit.swift
+++ b/Sources/NextcloudKit/NextcloudKit.swift
@@ -21,8 +21,12 @@ open class NextcloudKit {
     private let reachabilityManager = Alamofire.NetworkReachabilityManager()
 #endif
     public var nkCommonInstance = NKCommon()
+
     internal lazy var unauthorizedSession: Alamofire.Session = {
-        return Alamofire.Session(configuration: URLSessionConfiguration.af.default,
+        let configuration = URLSessionConfiguration.af.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+
+        return Alamofire.Session(configuration: configuration,
                                  delegate: NextcloudKitSessionDelegate(nkCommonInstance: nkCommonInstance),
                                  eventMonitors: [NKMonitor(nkCommonInstance: self.nkCommonInstance)])
     }()


### PR DESCRIPTION
@mpivchev figured it out and deserves the credit, I just cleaned up and squashed the branch.

The problem solved is that the iOS app polls some servers infinitely because their negative response is cached client-side even after the user granted app password in the web.