### PR TITLE
Structured Concurrency Wrappers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,12 @@ name: SwiftLint
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     branches:
-      - master
+      - main
       - develop
 
 jobs:

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -5,12 +5,12 @@ name: Build and test
 on:
   push:
     branches:
-      - master
+      - main
       - develop
   pull_request:
     types: [synchronize, opened, reopened, ready_for_review]
     branches:
-      - master
+      - main
       - develop
 
 env:

--- a/Sources/NextcloudKit/NKError.swift
+++ b/Sources/NextcloudKit/NKError.swift
@@ -32,7 +32,7 @@ extension OCSPath {
     static var ocsXMLMsg: Self { ["d:error", "s:message"] }
 }
 
-public struct NKError: Sendable, Equatable {
+public struct NKError: Error, Equatable {
     static let internalError = -9999
     // Chunk error
     public static let chunkNoEnoughMemory = -9998

--- a/Sources/NextcloudKit/NKShareAccounts.swift
+++ b/Sources/NextcloudKit/NKShareAccounts.swift
@@ -6,11 +6,33 @@ import Foundation
 #if os(iOS)
 import UIKit
 
+///
+/// Facility to read and write partial account information shared among apps of the same security group.
+/// This is the foundation for the quick account selection feature on login.
+///
 public class NKShareAccounts: NSObject {
-    public class DataAccounts: NSObject {
+    ///
+    /// Data transfer object to pass between ``NKShareAccounts`` and calling code.
+    ///
+    public class DataAccounts: NSObject, Identifiable {
+        ///
+        /// The server address of the account.
+        ///
         public var url: String
+
+        ///
+        /// The login name for the account.
+        ///
         public var user: String
+
+        ///
+        /// The display name of the account.
+        ///
         public var name: String?
+
+        ///
+        /// The ccount profile picture.
+        ///
         public var image: UIImage?
 
         public init(withUrl url: String, user: String, name: String? = nil, image: UIImage? = nil) {
@@ -34,6 +56,9 @@ public class NKShareAccounts: NSObject {
     internal let fileName: String = "accounts.json"
     internal let directoryAccounts: String = "Library/Application Support/NextcloudAccounts"
 
+    ///
+    /// Store shared account information in the app group container.
+    ///
     /// - Parameters:
     ///     - directory: the group directory of share the accounts (group.com.nextcloud.apps), use the  func containerURL(forSecurityApplicationGroupIdentifier groupIdentifier: String) -> URL? // Available for OS X in 10.8.3.
     ///     - app: the name of app
@@ -81,6 +106,9 @@ public class NKShareAccounts: NSObject {
         return nil
     }
 
+    ///
+    /// Read the shared account information from the app group container.
+    ///
     /// - Parameters:
     ///     - directory: the group directory of share the accounts (group.com.nextcloud.apps), use the  func containerURL(forSecurityApplicationGroupIdentifier groupIdentifier: String) -> URL? // Available for OS X in 10.8.3.
     ///     - application: the UIApplication used for verify if the app(s) is still installed

--- a/Sources/NextcloudKit/NextcloudKit+API.swift
+++ b/Sources/NextcloudKit/NextcloudKit+API.swift
@@ -151,6 +151,17 @@ public extension NextcloudKit {
         case failure(NKError)
     }
 
+    ///
+    /// Asynchronous method wrapper for ``getServerStatus(serverUrl:options:taskHandler:completion:)``.
+    ///
+    func getServerStatus(serverUrl: String, options: NKRequestOptions = NKRequestOptions(), taskHandler: @escaping (_ task: URLSessionTask) -> Void = { _ in }) async -> ServerInfoResult {
+        await withCheckedContinuation { continuation in
+            getServerStatus(serverUrl: serverUrl, options: options, taskHandler: taskHandler) { _, serverInfoResult in
+                continuation.resume(returning: serverInfoResult)
+            }
+        }
+    }
+
     func getServerStatus(serverUrl: String,
                          options: NKRequestOptions = NKRequestOptions(),
                          taskHandler: @escaping (_ task: URLSessionTask) -> Void = { _ in },

--- a/Sources/NextcloudKit/NextcloudKit+Login.swift
+++ b/Sources/NextcloudKit/NextcloudKit+Login.swift
@@ -99,6 +99,39 @@ public extension NextcloudKit {
 
     // MARK: - Login Flow V2
 
+    ///
+    /// Requests the initiation of a login process and retrieves required information.
+    ///
+    /// - Returns: A tuple consisting of the `endpoint` to poll for the login status with the `token`. Additionally, the `login` to open for the user to log in.
+    ///
+    func getLoginFlowV2(serverUrl: String, options: NKRequestOptions = NKRequestOptions(), taskHandler: @escaping (_ task: URLSessionTask) -> Void = { _ in }) async throws -> (endpoint: URL, login: URL, token: String) {
+        try await withCheckedThrowingContinuation { continuation in
+            getLoginFlowV2(serverUrl: serverUrl, options: options, taskHandler: taskHandler) { token, endpointString, loginString, _, error in
+                if error != .success {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                guard let endpointString, let endpointURL = URL(string: endpointString) else {
+                    continuation.resume(throwing: NKError.urlError)
+                    return
+                }
+
+                guard let loginString, let loginURL = URL(string: loginString) else {
+                    continuation.resume(throwing: NKError.urlError)
+                    return
+                }
+
+                guard let token else {
+                    continuation.resume(throwing: NKError.invalidData)
+                    return
+                }
+
+                continuation.resume(returning: (endpointURL, loginURL, token))
+            }
+        }
+    }
+
     func getLoginFlowV2(serverUrl: String,
                         options: NKRequestOptions = NKRequestOptions(),
                         taskHandler: @escaping (_ task: URLSessionTask) -> Void = { _ in },


### PR DESCRIPTION
* Raised minimum iOS version required to 13.
* Added two wrapper methods to enable structured concurrency in Swift.
* This is an improvement in scope of https://github.com/nextcloud/notes-ios/issues/97