### PR TITLE
fix: guard against negative nc:lock-timeout when computing lockTimeOut

### DIFF
--- a/Sources/NextcloudKit/Models/NKDataFileXML.swift
+++ b/Sources/NextcloudKit/Models/NKDataFileXML.swift
@@ -472,7 +472,7 @@ public class NKDataFileXML: NSObject {
             if let lockTime = propstat["d:prop", "nc:lock-time"].int {
                 file.lockTime = Date(timeIntervalSince1970: TimeInterval(lockTime))
             }
-            if let lockTimeOut = propstat["d:prop", "nc:lock-timeout"].int {
+            if let lockTimeOut = propstat["d:prop", "nc:lock-timeout"].int, lockTimeOut > 0 {
                 file.lockTimeOut = file.lockTime?.addingTimeInterval(TimeInterval(lockTimeOut))
             }
 


### PR DESCRIPTION
## Summary

- When `files_lock` is configured with infinite timeout (the default, `-1` minutes), the server sends `nc:lock-timeout=-60` via WebDAV PROPFIND
- Without a guard, `lockTimeOut` was computed as `lockTime + (-60 seconds)` — a date in the past
- Although `lockTimeOut` is not currently displayed in the iOS UI, this would cause incorrect behaviour if expiry display is added in future

The fix adds `lockTimeOut > 0` to the `if let` condition so `lockTimeOut` is only computed for genuine finite timeouts. Infinite locks leave it as `nil`.

The root cause fix is server-side in `files_lock` ([see related PR](https://github.com/nextcloud/files_lock)). This is a defensive client-side guard for servers that haven't been updated yet.

## Test plan

- [ ] Verify `lockTimeOut` is `nil` when `nc:lock-timeout` is absent or negative
- [ ] Verify `lockTimeOut` is correctly computed when `nc:lock-timeout` is a positive value

🤖 Generated with [Claude Code](https://claude.ai/claude-code)