### PR TITLE
Log fix

### DIFF
--- a/Sources/NextcloudKit/Log/NKLogFileManager.swift
+++ b/Sources/NextcloudKit/Log/NKLogFileManager.swift
@@ -115,7 +115,7 @@ public final class NKLogFileManager: @unchecked Sendable {
     private var blacklist: [String] = []
     private var whitelist: [String] = []
     private var currentLogDate: String
-    private let logQueue = DispatchQueue(label: "com.nextcloud.LogWriterQueue", attributes: .concurrent)
+    private let logQueue = DispatchQueue(label: "com.nextcloud.LogWriterQueue")
     private let rotationQueue = DispatchQueue(label: "com.nextcloud.LogRotationQueue")
     private let fileManager = FileManager.default
 


### PR DESCRIPTION
Fix log file writes by serializing the log writer queue.

The log writer queue now uses a serial DispatchQueue instead of a concurrent one. Since all log entries are appended to the same log file, concurrent writes could interleave seek/write operations and produce broken or incomplete log lines. Serializing the queue preserves log order and prevents corrupted log output.