### PR TITLE
feat(upload): Support If-Match precondition on chunked assembly

### DIFF
--- a/Sources/NextcloudKit/NextcloudKit+Upload.swift
+++ b/Sources/NextcloudKit/NextcloudKit+Upload.swift
@@ -188,6 +188,7 @@ public extension NextcloudKit {
     ///   - chunkSize: Desired chunk size in bytes.
     ///   - account: Account identifier.
     ///   - options: Request options (headers, timeout, etc.).
+    ///   - ifMatch: Optional ETag precondition applied **only** to the final assembly `MOVE` (not the chunk uploads). When set, the server rejects the assembly with `412 Precondition Failed` if the destination changed since this ETag, enabling optimistic-concurrency conflict detection for chunked uploads.
     ///   - chunkProgressHandler: Reports per-chunk preparation progress as `(totalChunks, currentIndex)`.
     ///   - uploadStart: Called once when upload of chunks begins, with the final list of chunks.
     ///   - uploadTaskHandler: Exposes the low-level `URLSessionTask` for each chunk upload.
@@ -210,6 +211,7 @@ public extension NextcloudKit {
                           chunkSize: Int,
                           account: String,
                           options: NKRequestOptions = NKRequestOptions(),
+                          ifMatch: String? = nil,
                           chunkProgressHandler: @escaping (_ total: Int, _ counter: Int) -> Void = { _, _ in },
                           uploadStart: @escaping (_ filesChunk: [(fileName: String, size: Int64)]) -> Void = { _ in },
                           uploadTaskHandler: @escaping (_ task: URLSessionTask) -> Void = { _ in },
@@ -410,6 +412,14 @@ public extension NextcloudKit {
         let assembleTimeMax: Double = 30 * 60   // 30 minutes
         options.timeout = max(assembleTimeMin, min(assembleTimePerGB * assembleSizeInGB, assembleTimeMax))
 
+        // Optimistic concurrency: guard the assembly against a concurrent change to
+        // the destination. The precondition must ride ONLY on the MOVE that
+        // materializes the final file — never on the chunk PUTs above, which target
+        // brand-new chunk resources and would spuriously fail with 412.
+        if let ifMatch {
+            options.customHeader?["If-Match"] = ifMatch
+        }
+
         assembling()
 
         let moveRes = await moveFileOrFolderAsync(serverUrlFileNameSource: serverUrlFileNameSource,
@@ -417,6 +427,11 @@ public extension NextcloudKit {
                                                   overwrite: true,
                                                   account: account,
                                                   options: options)
+
+        // Don't let the precondition leak onto the post-assembly PROPFIND readback:
+        // after a successful MOVE the destination carries a fresh etag, which would
+        // fail an If-Match against the pre-assembly value.
+        options.customHeader?["If-Match"] = nil
 
         guard moveRes.error == .success else {
             return (account, nil)


### PR DESCRIPTION
This is a fix to improve upload data integrity and conflict detection for chunked transmissions. This is based on actual customer support tickets and reports in conjunction with Adobe Creative Cloud apps.

## Summary

Adds an optional `ifMatch` parameter to `uploadChunkAsync` so clients can perform **optimistic-concurrency conflict detection on chunked (large-file) uploads**.

When set, the ETag precondition is applied **only** to the final assembly `MOVE` that materializes the destination file. If the destination changed since the base version the client edited, the server rejects the assembly with **412 Precondition Failed** instead of silently overwriting the newer copy.

## Why

Single-request `PUT` uploads can already carry `If-Match` via `NKRequestOptions.customHeader`. The chunked path could not: `uploadChunkAsync` reuses one `customHeader` bag for both the per-chunk `PUT`s and the assembly `MOVE`, so injecting `If-Match` there would ride on the chunk `PUT`s too — and those target brand-new chunk resources, so the precondition would spuriously fail with 412. This PR closes that gap.

The macOS desktop client uses this for save-conflict protection (Adobe Creative Suite rapid re-saves, multi-device edits); the single-PUT half is at nextcloud/desktop#10393. The chunked path will be wired there once this lands and is released.

## What changed

- New `ifMatch: String? = nil` parameter on `uploadChunkAsync`.
- Applied to `options.customHeader["If-Match"]` **only immediately before the assembly `MOVE`**, never during the chunk `PUT` loop.
- Cleared again right after the `MOVE`, so it does not leak onto the post-assembly PROPFIND readback (whose target carries a fresh ETag after a successful MOVE).

Default `nil` → existing callers are unaffected; behavior is identical unless a caller opts in.

## Testing

The core `NextcloudKit` target builds clean. The chunked path is WebDAV (PROPFIND/MKCOL/MOVE), which the repo's `Mocker`-based unit tests can't represent (standard HTTP methods only), so it is exercised via live-server integration testing — consistent with how the rest of the WebDAV surface is covered here. End-to-end conflict behavior will also be validated through the desktop client once its chunked path consumes this parameter.

> Note: `swift build` of the whole package currently fails in the unrelated `NextcloudKitUI` target (`WKWebView.isInspectable` needs macOS 13.3 but the package targets macOS 11) — pre-existing on `main`, untouched by this PR. The core `NextcloudKit` target builds cleanly.
